### PR TITLE
Remove print statements and fix typos

### DIFF
--- a/lib/advancedDataTableSource.dart
+++ b/lib/advancedDataTableSource.dart
@@ -4,7 +4,7 @@ typedef LoadPageCallback = Future<RemoteDataSourceDetails<F>> Function<F>(
     int pagesize, int offset);
 
 abstract class AdvancedDataTableSource<T> extends DataTableSource {
-  bool get initalRequestCompleted => lastDetails == null ? false : true;
+  bool get initialRequestCompleted => lastDetails == null ? false : true;
   RemoteDataSourceDetails<T>? lastDetails;
 
   Future<RemoteDataSourceDetails<T>> getNextPage(NextPageRequest pageRequest);
@@ -18,14 +18,14 @@ abstract class AdvancedDataTableSource<T> extends DataTableSource {
   bool forceRemoteReload = false;
 
   Future<int> loadNextPage(int pageSize, int offset, int? columnSortIndex,
-      bool? sortAsceding) async {
+      bool? sortAscending) async {
     try {
       lastDetails = await getNextPage(
         NextPageRequest(
           pageSize,
           offset,
           columnSortIndex: columnSortIndex,
-          sortAscending: sortAsceding,
+          sortAscending: sortAscending,
         ),
       );
       //If the remote source is filtered, its the important upper limit

--- a/lib/datatable.dart
+++ b/lib/datatable.dart
@@ -399,15 +399,9 @@ class PaginatedDataTableState extends State<AdvancedPaginatedDataTable> {
     final result = <DataRow>[];
     final nextPageFirstRowIndex = firstRowIndex + rowsPerPage;
     var haveProgressIndicator = false;
-    print('firstRow: $firstRowIndex');
-    print('nextPageFirstRowIndex: $nextPageFirstRowIndex');
     for (var index = firstRowIndex; index < nextPageFirstRowIndex; index += 1) {
       DataRow? row;
       if (index < _rowCount || _rowCountApproximate) {
-        print(
-            'index - x: $index - ${(firstRowIndex ~/ rowsPerPage) * rowsPerPage}');
-        print(
-            'index - start: $index - $firstRowIndex = ${index - firstRowIndex}');
         row = _rows.putIfAbsent(
             index,
             () => widget.source.getRow(index -
@@ -551,13 +545,10 @@ class PaginatedDataTableState extends State<AdvancedPaginatedDataTable> {
                 key: Key('rowsPerPage'),
                 items: availableRowsPerPage.cast<DropdownMenuItem<int>>(),
                 value: widget.rowsPerPage,
-                onTap: () {
-                  print('tapped the rows per page');
-                },
+                onTap: () {},
                 onChanged: (newRowsPerPage) {
                   if (newRowsPerPage != null &&
                       newRowsPerPage != widget.rowsPerPage) {
-                    print('change rows per page to $newRowsPerPage');
                     setLoadNextPage(rowsPerPage: newRowsPerPage);
                     if (widget.onRowsPerPageChanged != null) {
                       widget.onRowsPerPageChanged!(newRowsPerPage);


### PR DESCRIPTION
The print statements are too much and don't help anyone who is using this library. If there was a way to have these statements while developing this library but have them silenced elsewhere, I would. I just don't know a good way.