### PR TITLE
keep old datatable height during refresh

### DIFF
--- a/lib/datatable.dart
+++ b/lib/datatable.dart
@@ -620,7 +620,7 @@ class PaginatedDataTableState extends State<AdvancedPaginatedDataTable> {
                       showBottomBorder: true,
                       rows: loading
                           ? loadingRows(
-                              widget.rowsPerPage,
+                              widget.source.lastDetails?.rows.length ?? widget.rowsPerPage,
                             )
                           : _getRows(_firstRowIndex, widget.rowsPerPage),
                     ),


### PR DESCRIPTION
Hello,

I noticed that there is a loader during refresh or sorting, and the data table is filled with empty rows. The number of empty rows always equals page size but when we have fewer elements on the page, datatable expands its size during loading.
It's not looking very well.
![old](https://user-images.githubusercontent.com/5392781/174325131-d6de0a12-1555-4944-b071-3a9e3eec0673.gif)

I did some changes. Now the number of rendered blank rows is equal to the last visible row count, or to page size if there was no data loaded before the refresh.
![new](https://user-images.githubusercontent.com/5392781/174325146-4d4dc23e-659b-4457-aefa-a014d44d8b4a.gif)

Best Regards,
Kamil